### PR TITLE
Remove duplicate </p> tag from jetpack_admin_missing_autoloader() function

### DIFF
--- a/jetpack.php
+++ b/jetpack.php
@@ -199,7 +199,6 @@ if ( is_readable( $jetpack_autoloader ) ) {
 				);
 				?>
             </p>
-            </p>
         </div>
 		<?php
 	}


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request:
<!--- Explain what functional changes your PR includes -->
* In jetpack_admin_missing_autoloader notice function need to remove duplicate end **p** tag because it generate empty space in admin panel when we activate plugin.

#### Testing instructions:
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you working on is not obvious for everyone.  -->
<!-- Adding "simple" configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before / After" screenshots can also be very helpful when the change is visual. -->

* Install Jatpack plugin 
* Activate plugin

#### Proposed changelog entry for your changes:
<!-- Please do not leave this empty. If no changelog entry needed, state as such. -->
* Remove that end **p** tag so it will removed space from admin panel notice.

![Error](https://user-images.githubusercontent.com/10103365/59420215-1c68ba80-8dea-11e9-8aea-dbe8c72f69fd.png)
